### PR TITLE
Add player movement setting in the tacticboard:

### DIFF
--- a/js/util/g2.js
+++ b/js/util/g2.js
@@ -278,9 +278,15 @@ function G2() {
         }
         this.handleEvent = () => {
             let uvz = g2.getUVZ_R(obj);
-            if (uvz) {
-                pList[tacticBoard.currPlayer].position[0] = Math.max(0, Math.min(1, (uvz[0] - (x - w / 2)) / w)) * 2 - 1;
-                pList[tacticBoard.currPlayer].position[1] = Math.max(0, Math.min(1, (uvz[1] - (y - h / 2)) / h)) * 2 - 1;
+            if (uvz && tacticBoard.currPlayer != -1) {
+                // Determine postion in which time point (start or end) is changing.
+                if (!tacticBoard.started_setting && tacticBoard.endTime != -1) {
+                    pList[tacticBoard.currPlayer].positions[tacticBoard.endTime][0] = Math.max(0, Math.min(1, (uvz[0] - (x - w / 2)) / w)) * 2 - 1;
+                    pList[tacticBoard.currPlayer].positions[tacticBoard.endTime][1] = Math.max(0, Math.min(1, (uvz[1] - (y - h / 2)) / h)) * 2 - 1;    
+                } else if (tacticBoard.started_setting && tacticBoard.startTime != -1) {
+                    pList[tacticBoard.currPlayer].positions[tacticBoard.startTime][0] = Math.max(0, Math.min(1, (uvz[0] - (x - w / 2)) / w)) * 2 - 1;
+                    pList[tacticBoard.currPlayer].positions[tacticBoard.startTime][1] = Math.max(0, Math.min(1, (uvz[1] - (y - h / 2)) / h)) * 2 - 1;    
+                }
                 if (action && mouseState == 'drag')
                     action();
             }
@@ -292,16 +298,54 @@ function G2() {
             g2.fillRect(x - w / 2, y - h / 2, w, h);
             g2.setColor(color, isPressed ? .375 : this.isWithin() ? .475 : .5);
             for (let i = 0; i < pList.length; i++) {
-                let player = pList[i];
-                let pos = player.pos2D();
-                // draw player box
-                g2.setColor(player.color);
-                let posOnTrackPad = [x + w * pos[0] / 2, y + h * pos[1] / 2]
-                g2.fillRect(posOnTrackPad[0] - .015 * size, posOnTrackPad[1] - .015 * size, .03 * size, .03 * size);
 
-                // draw direction arrow
-                g2.lineWidth(.005);
-                g2.arrow(posOnTrackPad, [posOnTrackPad[0] + Math.cos(player.direction)*.05, posOnTrackPad[1] + Math.sin(player.direction)*.05]);
+                // TO DO:
+                // Add code for direction drawing.
+
+                let player = pList[i];
+                let start = player.getStartAndEnd()[0];
+                let end = player.getStartAndEnd()[1];
+
+                // if no point selected, draw the initial pos
+                if (start == 24) {
+                    let pos = player.initialPosition;
+                    g2.setColor(player.color);
+                    let posOnTrackPad = [x + w * pos[0] / 2, y + h * pos[1] / 2];
+                    g2.fillRect(posOnTrackPad[0] - .015 * size, posOnTrackPad[1] - .015 * size, .03 * size, .03 * size);
+                } else {
+                    // if having start point, draw it with time as label
+                    let pos = player.positions[start];
+                    g2.setColor(player.color);
+                    let posOnTrackPad = [x + w * pos[0] / 2, y + h * pos[1] / 2];
+                    g2.fillRect(posOnTrackPad[0] - .015 * size, posOnTrackPad[1] - .015 * size, .03 * size, .03 * size);
+                    g2.setColor('black');
+                    g2.textHeight(.025);
+                    g2.fillText(start + '', posOnTrackPad[0], posOnTrackPad[1], 'center');
+                    if (start < end) {
+                        // if having end point, draw it with time as label
+                        let pos2 = player.positions[end];
+                        g2.setColor(player.color);
+                        let pos2OnTrackPad = [x + w * pos2[0] / 2, y + h * pos2[1] / 2];
+                        g2.fillRect(pos2OnTrackPad[0] - .015 * size, pos2OnTrackPad[1] - .015 * size, .03 * size, .03 * size);
+                        g2.setColor('black');
+                        g2.textHeight(.025);
+                        g2.fillText(end + '', pos2OnTrackPad[0], pos2OnTrackPad[1], 'center');
+
+                        // draw a line from start point to end point
+                        g2.setColor(player.color);
+                        g2.lineWidth(.003);
+                        g2.line(posOnTrackPad, pos2OnTrackPad);
+                    }
+                }
+                // let pos = player.pos2D();
+                // // draw player box
+                // g2.setColor(player.color);
+                // let posOnTrackPad = [x + w * pos[0] / 2, y + h * pos[1] / 2]
+                // g2.fillRect(posOnTrackPad[0] - .015 * size, posOnTrackPad[1] - .015 * size, .03 * size, .03 * size);
+
+                // // draw direction arrow
+                // g2.lineWidth(.005);
+                // g2.arrow(posOnTrackPad, [posOnTrackPad[0] + Math.cos(player.direction)*.05, posOnTrackPad[1] + Math.sin(player.direction)*.05]);
             }
             g2.setColor('black');
             g2.fillText(label, x, y, 'center');


### PR DESCRIPTION
1. The time button now shows the move of the selected player.
2. Click once set the start timepoint and choose position for this timepoint in the trackpad, click the second time to choose the endpoint.
3. Now trackpad can display both the startpoint and the endpoint in the pad, with a label of the number of this timepoint.
4. Some UI changes.